### PR TITLE
Add `excludeRetweets` option to `ofTweets` Channel factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following options are available:
 
 | Operator option  | Description                  |
 |---             |---                         |
-| `exclude_retweets`              | The default value is false. Set to true to exclude pure retweets (retweet with message is still included, though).
+| `excludeRetweets`              | The default value is false. Set to true to exclude pure retweets (retweet with message is still included, though).
 
 ### Getting started with plugin dev
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ plugins {
 }
 ```
 
+Currently, there is only one channel factory called `ofTweets`, where you can query tweets based on a string. By default, it considers the latest 20 tweets in the last 24 hours. For now, there is only one option implemented for this channel factory, as you can see below:
+
+The following options are available:
+
+| Operator option  | Description                  |
+|---             |---                         |
+| `exclude_retweets`              | The default value is false. Set to true to exclude pure retweets (retweet with message is still included, though).
+
 ### Getting started with plugin dev
 
 1. Clone this repo

--- a/plugins/nf-tweet/src/main/nextflow/tweet/TweetExtension.groovy
+++ b/plugins/nf-tweet/src/main/nextflow/tweet/TweetExtension.groovy
@@ -6,6 +6,7 @@ import nextflow.Session
 import nextflow.extension.CH
 import nextflow.plugin.extension.Factory
 import nextflow.plugin.extension.PluginExtensionPoint
+import nextflow.util.CheckHelper
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -25,6 +26,10 @@ import java.nio.charset.StandardCharsets
  */
 class TweetExtension extends PluginExtensionPoint {
 
+    private static final Map OFTWEETS_PARAMS = [
+            exclude_retweets: Boolean,
+    ]
+
     private Session session
 
     @Override
@@ -35,25 +40,42 @@ class TweetExtension extends PluginExtensionPoint {
 
     @Factory
     DataflowWriteChannel ofTweets(String query) {
+        ofTweets(Collections.emptyMap(), query)
+    }
+
+    @Factory
+    DataflowWriteChannel ofTweets(Map opts, String query) {
+        CheckHelper.checkParams('ofTweets', opts, OFTWEETS_PARAMS)
+        return QueryOfTweets(opts, query)
+    }
+
+    @Factory
+    DataflowWriteChannel QueryOfTweets(Map opts, String query) {
+        // The location of the bearer token file, env var or whatever should
+        // be set in the `nextflow.config` file. For now, let's do it the easy
+        // way here.
         String bearerToken = new File("twitter_bearer_token").text.strip()
+        CheckHelper.checkParams('ofTweets', opts, OFTWEETS_PARAMS)
         final channel = CH.create()
-        session.addIgniter(it -> emitTweets(channel, query, bearerToken) )
+        session.addIgniter(it -> emitTweets(channel, query, opts, bearerToken) )
         return channel
     }
 
-    protected void emitTweets(DataflowWriteChannel channel, query, bearerToken) {
+    protected void emitTweets(DataflowWriteChannel channel, query, opts, bearerToken) {
         def end_time = new Date().getTime()
         def start_time = end_time - (24 * 60 * 60 * 1000)
-        def exclude_retweets=true
+        def exclude_retweets=opts.exclude_retweets
         def max_results=20
         // Formating dates adequately
         String start_time_str = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(start_time);
         String end_time_str = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(end_time);
         // Formating query adequately
         def query_string = query.replace(' ', '%20')
-        String optional_query = ''
+        String optional_query
         if (exclude_retweets) {
             optional_query = '%20-is:retweet'
+        } else {
+            optional_query = ''
         }
 
         String url = "https://api.twitter.com/2/tweets/search/recent?query=" +\

--- a/plugins/nf-tweet/src/main/nextflow/tweet/TweetExtension.groovy
+++ b/plugins/nf-tweet/src/main/nextflow/tweet/TweetExtension.groovy
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets
 class TweetExtension extends PluginExtensionPoint {
 
     private static final Map OFTWEETS_PARAMS = [
-            exclude_retweets: Boolean,
+            excludeRetweets: Boolean,
     ]
 
     private Session session
@@ -64,27 +64,21 @@ class TweetExtension extends PluginExtensionPoint {
     protected void emitTweets(DataflowWriteChannel channel, query, opts, bearerToken) {
         def end_time = new Date().getTime()
         def start_time = end_time - (24 * 60 * 60 * 1000)
-        def exclude_retweets=opts.exclude_retweets
+        def exclude_retweets=opts.excludeRetweets
         def max_results=20
         // Formating dates adequately
         String start_time_str = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(start_time);
         String end_time_str = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(end_time);
         // Formating query adequately
         def query_string = query.replace(' ', '%20')
-        String optional_query
-        if (exclude_retweets) {
-            optional_query = '%20-is:retweet'
-        } else {
-            optional_query = ''
-        }
-
+        def optional_query = exclude_retweets ? '%20-is:retweet' : ''
         String url = "https://api.twitter.com/2/tweets/search/recent?query=" +\
                         query_string + optional_query +\
                         "&start_time=${start_time_str}" +\
                         "&end_time=${end_time_str}" +\
                         "&tweet.fields=created_at,author_id" +\
                         "&max_results=${max_results}"
-        URL obj = new URL(url);
+        println(url)
         HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 
         con.setRequestMethod("GET");

--- a/tweet.nf
+++ b/tweet.nf
@@ -2,7 +2,7 @@ include { ofTweets } from 'plugin/nf-tweet'
 
 
 Channel
-  .ofTweets('nextflow', exclude_retweets: true)
+  .ofTweets('nextflow', excludeRetweets: true)
   .map { author, date_tweet -> author }
   .collect()
   .view()

--- a/tweet.nf
+++ b/tweet.nf
@@ -2,7 +2,7 @@ include { ofTweets } from 'plugin/nf-tweet'
 
 
 Channel
-  .ofTweets('Nextflow')
+  .ofTweets('nextflow', exclude_retweets: true)
   .map { author, date_tweet -> author }
   .collect()
   .view()


### PR DESCRIPTION
When you query tweets with the Twitter API, some of them will be original tweets, some will be raw retweets and some of them will be original tweets with another tweet attached to it (retweet with message). Original tweets and original tweets with another tweet attached is usually what users are looking for, though not always, so this PR provides an option to exclude these "raw" retweets.